### PR TITLE
Correct regular expression for compile time arrays

### DIFF
--- a/syntaxes/rpg.tmLanguage
+++ b/syntaxes/rpg.tmLanguage
@@ -149,7 +149,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^[*]{2,2}</string>
+			<string>(?i)^[*]{2,2}(ctdata)?\ </string>
 			<key>comment</key>
 			<string>Compile time array in the bottom of the source file</string>
 			<key>end</key>


### PR DESCRIPTION
The previous expression matched the new **FREE specification for fully free-form RPG.